### PR TITLE
go: Use GOMODCACHE for pure build

### DIFF
--- a/quotes-app-go/.flox/env/manifest.lock
+++ b/quotes-app-go/.flox/env/manifest.lock
@@ -34,10 +34,10 @@
         "description": "Quotes App written in Go"
       },
       "quotes-app-go-deps": {
-        "command": "  mkdir -p $out/etc\n  cp -r ./vendor $out/etc/vendor\n  chmod +x $out\n"
+        "command": "  export GOMODCACHE=$out\n  go mod download -modcacherw\n"
       },
       "quotes-app-go-pure": {
-        "command": "  mkdir -p $out/{lib,bin}\n  cp -pr quotes.json $out/lib\n  cp -r ${quotes-app-go-deps}/etc/vendor ./vendor\n  go build -trimpath -o $out/bin/quotes-app-go-pure main.go\n  chmod +x $out/bin/quotes-app-go-pure\n",
+        "command": "  export GOMODCACHE=${quotes-app-go-deps}\n  mkdir -p $out/{lib,bin}\n  cp -pr quotes.json $out/lib\n  go build -trimpath -o $out/bin/quotes-app-go-pure main.go\n  chmod +x $out/bin/quotes-app-go-pure\n",
         "runtime-packages": [
           "iana-etc",
           "mailcap",

--- a/quotes-app-go/.flox/env/manifest.lock
+++ b/quotes-app-go/.flox/env/manifest.lock
@@ -23,9 +23,6 @@
       }
     },
     "build": {
-      "deps": {
-        "command": "  mkdir -p $out/etc\n  cp -r ./vendor $out/etc/vendor\n  chmod +x $out\n"
-      },
       "quotes-app-go": {
         "command": "  mkdir -p $out/{lib,bin}\n  cp -pr quotes.json $out/lib\n\tgo mod tidy\n  go build -trimpath -o $out/bin/quotes-app-go main.go\n  chmod +x $out/bin/quotes-app-go\n",
         "runtime-packages": [
@@ -36,8 +33,11 @@
         "version": "0.0.1",
         "description": "Quotes App written in Go"
       },
+      "quotes-app-go-deps": {
+        "command": "  mkdir -p $out/etc\n  cp -r ./vendor $out/etc/vendor\n  chmod +x $out\n"
+      },
       "quotes-app-go-pure": {
-        "command": "  mkdir -p $out/{lib,bin}\n  cp -pr quotes.json $out/lib\n  cp -r ${deps}/etc/vendor ./vendor\n  go build -trimpath -o $out/bin/quotes-app-go-pure main.go\n  chmod +x $out/bin/quotes-app-go-pure\n",
+        "command": "  mkdir -p $out/{lib,bin}\n  cp -pr quotes.json $out/lib\n  cp -r ${quotes-app-go-deps}/etc/vendor ./vendor\n  go build -trimpath -o $out/bin/quotes-app-go-pure main.go\n  chmod +x $out/bin/quotes-app-go-pure\n",
         "runtime-packages": [
           "iana-etc",
           "mailcap",

--- a/quotes-app-go/.flox/env/manifest.toml
+++ b/quotes-app-go/.flox/env/manifest.toml
@@ -23,7 +23,7 @@ runtime-packages = [
   "tzdata",
 ]
 
-[build.deps]
+[build.quotes-app-go-deps]
 command = '''
   mkdir -p $out/etc
   cp -r ./vendor $out/etc/vendor
@@ -36,7 +36,7 @@ description = "Quotes App written in Go"
 command = """
   mkdir -p $out/{lib,bin}
   cp -pr quotes.json $out/lib
-  cp -r ${deps}/etc/vendor ./vendor
+  cp -r ${quotes-app-go-deps}/etc/vendor ./vendor
   go build -trimpath -o $out/bin/quotes-app-go-pure main.go
   chmod +x $out/bin/quotes-app-go-pure
 """

--- a/quotes-app-go/.flox/env/manifest.toml
+++ b/quotes-app-go/.flox/env/manifest.toml
@@ -25,18 +25,17 @@ runtime-packages = [
 
 [build.quotes-app-go-deps]
 command = '''
-  mkdir -p $out/etc
-  cp -r ./vendor $out/etc/vendor
-  chmod +x $out
+  export GOMODCACHE=$out
+  go mod download -modcacherw
 '''
 
 [build.quotes-app-go-pure]
 version = "0.0.1"
 description = "Quotes App written in Go"
 command = """
+  export GOMODCACHE=${quotes-app-go-deps}
   mkdir -p $out/{lib,bin}
   cp -pr quotes.json $out/lib
-  cp -r ${quotes-app-go-deps}/etc/vendor ./vendor
   go build -trimpath -o $out/bin/quotes-app-go-pure main.go
   chmod +x $out/bin/quotes-app-go-pure
 """

--- a/test.sh
+++ b/test.sh
@@ -16,7 +16,7 @@ ENVS=$(find ./* -type d -prune -print |xargs -0 | tr -d './')
 declare -a DEFAULT_BUILD_MODIFIERS
 DEFAULT_BUILD_MODIFIERS=("" "-pure")
 declare -a FIXME_BUILDS
-FIXME_BUILDS=("quotes-app-python-pure" "quotes-app-jvm-pure" "quotes-app-go-pure" "quotes-app-nodejs-pure" "quotes-app-rb-pure" "quotes-app-rs-pure")
+FIXME_BUILDS=("quotes-app-python-pure" "quotes-app-jvm-pure" "quotes-app-nodejs-pure" "quotes-app-rb-pure" "quotes-app-rs-pure")
 
 # Global test results
 declare -a TEST_RESULTS


### PR DESCRIPTION
⚠️ This works after: https://github.com/flox/flox/pull/3257

So that we don't write any state to the current working directory which
may or may not behave the same on subsequent builds. The build was
previously missing a `go mod vendor` step, which is a good example of
the problem because the untracked dir probably existed in a working
directory at some point.

    % nix run github:flox/flox/brantley/remove-layered-activation-from-manifest-build -- build
    Rendering quotes-app-go-deps build script to /tmp/ce9fea35/quotes-app-go-deps/build.bash
    Building quotes-app-go-deps-0.0.0 in local mode
    00:00:00.003104 + export GOMODCACHE=/tmp/store_d0cc6e331f03b4349e94f9f1e684aef6-quotes-app-go-deps-0.0.0
    00:00:00.003106 + GOMODCACHE=/tmp/store_d0cc6e331f03b4349e94f9f1e684aef6-quotes-app-go-deps-0.0.0
    00:00:00.003112 + go mod download -modcacherw
    Completed build of quotes-app-go-deps-0.0.0 in local mode

    Rendering quotes-app-go-pure build script to /tmp/ce9fea35/quotes-app-go-pure/build.bash
    Building quotes-app-go-pure-0.0.1 in Nix sandbox (pure) mode
    this derivation will be built:
      /nix/store/smzizmhlahinrnh416axf966mm2dhglj-quotes-app-go-pure-0.0.1.drv
    building '/nix/store/smzizmhlahinrnh416axf966mm2dhglj-quotes-app-go-pure-0.0.1.drv'...
    quotes-app-go-pure> ---
    quotes-app-go-pure> Input checksums:
    quotes-app-go-pure> e8cca8f77f12c335bf8a186fd5789040  /nix/store/f4ly6izxa0ixm3jvhnfyiafnh7wcldan-src.tar
    quotes-app-go-pure> 7bff26e49b0a2f3d81c1528dc31e7f82  /nix/store/jwzs72sfxk33y5syjij0hpwjrrggrnmz-build.bash
    quotes-app-go-pure> 016b704b416a6d91091687e4f7d8b956  /nix/store/z25nk5i8xdd22f05l053f9mh6g1szx27-buildCache.tar
    quotes-app-go-pure> ---
    quotes-app-go-pure> 00:00:00.003462 + export GOMODCACHE=/nix/store/9bcf5xj6lbh3kqxv724kkxp2f2yqzj2f-quotes-app-go-deps-0.0.0
    quotes-app-go-pure> 00:00:00.003462 + GOMODCACHE=/nix/store/9bcf5xj6lbh3kqxv724kkxp2f2yqzj2f-quotes-app-go-deps-0.0.0
    quotes-app-go-pure> 00:00:00.003477 + mkdir -p /nix/store/d78dq9wnl73jh0dw2lyf5vjhvvm5vw65-quotes-app-go-pure-0.0.1/lib /nix/store/d78dq9wnl73jh0dw2lyf5vjhvvm5vw65-quotes-app-go-pure-0.0.1/bin
    quotes-app-go-pure> 00:00:00.005409 + cp -pr quotes.json /nix/store/d78dq9wnl73jh0dw2lyf5vjhvvm5vw65-quotes-app-go-pure-0.0.1/lib
    quotes-app-go-pure> 00:00:00.007351 + go build -trimpath -o /nix/store/d78dq9wnl73jh0dw2lyf5vjhvvm5vw65-quotes-app-go-pure-0.0.1/bin/quotes-app-go-pure main.go
    quotes-app-go-pure> 00:00:04.696701 + chmod +x /nix/store/d78dq9wnl73jh0dw2lyf5vjhvvm5vw65-quotes-app-go-pure-0.0.1/bin/quotes-app-go-pure
    quotes-app-go-pure> patching script interpreter paths in /nix/store/d78dq9wnl73jh0dw2lyf5vjhvvm5vw65-quotes-app-go-pure-0.0.1/bin/quotes-app-go-pure
    quotes-app-go-pure> signing /nix/store/d78dq9wnl73jh0dw2lyf5vjhvvm5vw65-quotes-app-go-pure-0.0.1
    Completed build of quotes-app-go-pure-0.0.1 in Nix sandbox mode

    Rendering quotes-app-go build script to /tmp/ce9fea35/quotes-app-go/build.bash
    Building quotes-app-go-0.0.1 in local mode
    00:00:00.003364 + mkdir -p /tmp/store_c7718e8d2d213bfdf85ff14932c546ac-quotes-app-go-0.0.1/lib /tmp/store_c7718e8d2d213bfdf85ff14932c546ac-quotes-app-go-0.0.1/bin
    00:00:00.005301 + cp -pr quotes.json /tmp/store_c7718e8d2d213bfdf85ff14932c546ac-quotes-app-go-0.0.1/lib
    00:00:00.007174 + go mod tidy
    00:00:00.031411 + go build -trimpath -o /tmp/store_c7718e8d2d213bfdf85ff14932c546ac-quotes-app-go-0.0.1/bin/quotes-app-go main.go
    00:00:00.385268 + chmod +x /tmp/store_c7718e8d2d213bfdf85ff14932c546ac-quotes-app-go-0.0.1/bin/quotes-app-go
    Completed build of quotes-app-go-0.0.1 in local mode

    ✨ Builds completed successfully.
    Outputs created: ./result-quotes-app-go-deps, ./result-quotes-app-go-pure, ./result-quotes-app-go-pure-buildCache, ./result-quotes-app-go-pure-log, ./result-quotes-app-go