### PR TITLE
Allow FLOXBIN to be a nix run command

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,12 @@ If that returns a 200, it's working.
 
 You can also run `make ruby` or `make go`, etc
 
+An alternate Flox binary can be provided with `FLOXBIN` which can also be used to provide different versions ad-hoc:
+
+``` bash
+FLOXBIN="nix run github:flox/flox/v1.4.4 --"
+```
+
 
 # Using
 `cd` to the directory of the language you want to build and run the following command:

--- a/test.sh
+++ b/test.sh
@@ -27,8 +27,8 @@ build_app() {
   local build_name="$2"
 	echo "🔨 Building $build_name with Flox..."
 	pushd "$env_name" > /dev/null
-	"$FLOXBIN" build clean 
-	"$FLOXBIN" build "$build_name"
+	$FLOXBIN build clean
+	$FLOXBIN build "$build_name"
 	popd > /dev/null
 }
 


### PR DESCRIPTION
I find this useful to test changes from tags and feature branches, e.g.

    % FLOXBIN="nix run github:flox/flox/brantley/remove-layered-activation-from-manifest-build --" make
    ./test.sh
    Using flox binary: nix run github:flox/flox/brantley/remove-layered-activation-from-manifest-build --
    🔨 Building quotes-app-cpp with Flox...

The recent addition of quoting prevented this:

    % FLOXBIN="nix run github:flox/flox/brantley/remove-layered-activation-from-manifest-build --" make
    ./test.sh
    Using flox binary: nix run github:flox/flox/brantley/remove-layered-activation-from-manifest-build --
    🔨 Building quotes-app-cpp with Flox...
    ./test.sh: line 30: nix run github:flox/flox/brantley/remove-layered-activation-from-manifest-build --: No such file or directory
    make: *** [test] Error 127