### PR TITLE
test: Use nix run github:flox/flox

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -12,20 +12,30 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: "Install Flox"
-        uses: "flox/install-flox-action@main"
+      - name: "Install Nix"
+        uses: "cachix/install-nix-action@v31"
+        with:
+          # `accept-flake-config` is required for substitution despite of also
+          # setting `substituters` and `trusted-public-keys` here.
+          extra_nix_config: |
+            accept-flake-config = true
+            experimental-features = nix-command flakes
+            substituters = https://cache.flox.dev https://cache.nixos.org/
+            trusted-public-keys = flox-cache-public-1:7F4OyH7ZCnFhcze3fJdfyXYLQw/aV7GEed86nQ7IsOs= cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY=
 
+      # Test against the `main` branch of `flox/flox` so that we can exercise
+      # new fixes, features, and catch regressions.
       - name: "Set FLOXBIN env var"
-        run: echo "FLOXBIN=$(which flox)" >> $GITHUB_ENV
-
-      - name: "Enable build features"
-        run: flox config --set-bool features.build true
+        run: echo "FLOXBIN=nix run github:flox/flox --" >> $GITHUB_ENV
 
       - name: "Show flox binary path"
         run: echo "Flox is at $FLOXBIN"
 
       - name: "Run flox version"
         run: $FLOXBIN --version
+
+      - name: "Enable build features"
+        run: $FLOXBIN config --set-bool features.build true
 
       - name: "Run make"
         run: make

--- a/test.sh
+++ b/test.sh
@@ -4,10 +4,10 @@ set -euo pipefail
 
 # Set which flox you want to use
 if [ -z "${FLOXBIN:-}" ]; then
-  FLOXBIN="$(which flox)"
+  FLOXBIN="nix run github:flox/flox --"
 fi
 
-echo "Using flox binary: $FLOXBIN"
+echo "Using flox command: $FLOXBIN"
 
 # Config
 BASE_PORT=3000


### PR DESCRIPTION
Test against HEAD of the `main` branch so that we can exercise new
fixes, features, and catch regressions.

This is needed right now to unblock the PRs for pure manifest builds
which depend on a fix that has just been merged in `flox/flox`. We can
figure out later on how to gate unreleased feature changes to the
examples.

It doesn't quite feel right defining the default in two places but I'm
slightly uncomfortable with only declaring it in one and it matches the
existing style.

Switched to a plain Nix installer since it's confusing to have an unused
Flox binary available, it's slightly faster, and we can apply the
changes to `nix.conf` more easily.