### PR TITLE
feat: allow remote trigger of this workflow

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -2,8 +2,8 @@ name: Test Manifest Builds
 
 on:
   pull_request:
-
-
+  workflow_dispatch:
+  
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
In order to run builds of the examples upon upstream changes to flox, expose a `workflow_dispatch` trigger, to be used in remote workflows.