### PR TITLE
fix(python): Fix pure build and backport to impure

### DIFF
--- a/quotes-app-python/.flox/env/manifest.lock
+++ b/quotes-app-python/.flox/env/manifest.lock
@@ -23,15 +23,20 @@
     "options": {},
     "build": {
       "quotes-app-python": {
-        "command": "  # Install to a new virtualenv.\n  export POETRY_VIRTUALENVS_PATH=$out\n  export POETRY_VIRTUALENVS_IN_PROJECT=false\n  export POETRY_VIRTUALENVS_OPTIONS_NO_PIP=true\n  echo \"VENV_PATH is $POETRY_VIRTUALENVS_PATH\"\n  poetry install\n\n  # Symlink any executables from the virtualenv.\n  mkdir -p \"${out}/bin\"\n  cd $out/bin\n  ln -s ../*/bin/quotes-app-python .\n",
+        "command": "  mkdir $out\n\n  # Prevent install being a noop when run from an existing activation that\n  # already has the virtualenv and dependencies installed.\n  unset VIRTUAL_ENV\n  export POETRY_VIRTUALENVS_PATH=$out\n  export POETRY_VIRTUALENVS_IN_PROJECT=false\n\n  # Install dependencies to the virtualenv.\n  poetry install --no-root\n\n  # Build and install our project to the virtualenv.\n  poetry build --format wheel\n  poetry run pip install dist/quotes_app_python-*.whl\n\n  # Copy the binstub from the virtualenv to be wrapped by Flox.\n  venv_path=\"$(poetry env info --path)\"\n  mkdir -p \"${out}/bin\"\n  cp \"${venv_path}/bin/quotes-app-python\" \"${out}/bin/quotes-app-python\"\n",
         "runtime-packages": [
           "python3"
         ],
         "version": "0.0.1",
         "description": "A simple Python app that prints a random quote from a list of quotes."
       },
+      "quotes-app-python-deps": {
+        "command": "  mkdir $out\n\n  # Prevent install being a noop when run from an existing activation that\n  # already has the virtualenv and dependencies installed.\n  unset VIRTUAL_ENV\n  export POETRY_VIRTUALENVS_PATH=$out\n  export POETRY_VIRTUALENVS_IN_PROJECT=false\n\n  # Install dependencies and cache them in the build output.\n  export POETRY_CACHE_DIR=$out\n  poetry install --no-root\n\n  # Poetry doesn't have a way to populate the cache without installing the\n  # dependencies so we just delete the virtualenv after.\n  venv_path=\"$(poetry env info --path)\"\n  rm -rf \"$venv_path\"\n",
+        "version": "0.0.1",
+        "description": "Vendored dependencies for the quotes server"
+      },
       "quotes-app-python-pure": {
-        "command": "  # Install to a new virtualenv.\n  export POETRY_VIRTUALENVS_PATH=$out\n  export POETRY_VIRTUALENVS_IN_PROJECT=false\n  export POETRY_VIRTUALENVS_OPTIONS_NO_PIP=true\n  poetry install\n\n  # Symlink any executables from the virtualenv.\n  mkdir -p \"${out}/bin\"\n  cd $out/bin\n  ln -s ../*/bin/quotes-app-python-pure .\n",
+        "command": "  mkdir $out\n\n  # Create an isolated virtualenv with the correct `python` and `site-packages`\n  # from this build.\n  export POETRY_VIRTUALENVS_PATH=$out\n  export POETRY_VIRTUALENVS_IN_PROJECT=false\n\n  # Install cached dependencies from the deps build.\n  export POETRY_CACHE_DIR=${quotes-app-python-deps}\n  poetry install --no-root\n\n  # Build and install our project to the virtualenv.\n  poetry build --format wheel\n  poetry run pip install dist/quotes_app_python-*.whl\n\n  # Copy the binstub from the virtualenv to be wrapped by Flox.\n  venv_path=\"$(poetry env info --path)\"\n  mkdir -p \"${out}/bin\"\n  cp \"${venv_path}/bin/quotes-app-python\" \"${out}/bin/quotes-app-python-pure\"\n",
         "runtime-packages": [
           "python3"
         ],

--- a/quotes-app-python/.flox/env/manifest.toml
+++ b/quotes-app-python/.flox/env/manifest.toml
@@ -70,36 +70,75 @@ zsh = """
 description = "A simple Python app that prints a random quote from a list of quotes."
 version = "0.0.1"
 command = """
-  # Install to a new virtualenv.
+  mkdir $out
+
+  # Prevent install being a noop when run from an existing activation that
+  # already has the virtualenv and dependencies installed.
+  unset VIRTUAL_ENV
   export POETRY_VIRTUALENVS_PATH=$out
   export POETRY_VIRTUALENVS_IN_PROJECT=false
-  export POETRY_VIRTUALENVS_OPTIONS_NO_PIP=true
-  echo "VENV_PATH is $POETRY_VIRTUALENVS_PATH"
-  poetry install
 
-  # Symlink any executables from the virtualenv.
+  # Install dependencies to the virtualenv.
+  poetry install --no-root
+
+  # Build and install our project to the virtualenv.
+  poetry build --format wheel
+  poetry run pip install dist/quotes_app_python-*.whl
+
+  # Copy the binstub from the virtualenv to be wrapped by Flox.
+  venv_path="$(poetry env info --path)"
   mkdir -p "${out}/bin"
-  cd $out/bin
-  ln -s ../*/bin/quotes-app-python .
+  cp "${venv_path}/bin/quotes-app-python" "${out}/bin/quotes-app-python"
 """
 runtime-packages = [
   "python3",
 ]
 
+[build.quotes-app-python-deps]
+description = "Vendored dependencies for the quotes server"
+version = "0.0.1"
+command = """
+  mkdir $out
+
+  # Prevent install being a noop when run from an existing activation that
+  # already has the virtualenv and dependencies installed.
+  unset VIRTUAL_ENV
+  export POETRY_VIRTUALENVS_PATH=$out
+  export POETRY_VIRTUALENVS_IN_PROJECT=false
+
+  # Install dependencies and cache them in the build output.
+  export POETRY_CACHE_DIR=$out
+  poetry install --no-root
+
+  # Poetry doesn't have a way to populate the cache without installing the
+  # dependencies so we just delete the virtualenv after.
+  venv_path="$(poetry env info --path)"
+  rm -rf "$venv_path"
+"""
+
 [build.quotes-app-python-pure]
 description = "A simple Python app that prints a random quote from a list of quotes."
 version = "0.0.1"
 command = """
-  # Install to a new virtualenv.
+  mkdir $out
+
+  # Create an isolated virtualenv with the correct `python` and `site-packages`
+  # from this build.
   export POETRY_VIRTUALENVS_PATH=$out
   export POETRY_VIRTUALENVS_IN_PROJECT=false
-  export POETRY_VIRTUALENVS_OPTIONS_NO_PIP=true
-  poetry install
 
-  # Symlink any executables from the virtualenv.
+  # Install cached dependencies from the deps build.
+  export POETRY_CACHE_DIR=${quotes-app-python-deps}
+  poetry install --no-root
+
+  # Build and install our project to the virtualenv.
+  poetry build --format wheel
+  poetry run pip install dist/quotes_app_python-*.whl
+
+  # Copy the binstub from the virtualenv to be wrapped by Flox.
+  venv_path="$(poetry env info --path)"
   mkdir -p "${out}/bin"
-  cd $out/bin
-  ln -s ../*/bin/quotes-app-python-pure .
+  cp "${venv_path}/bin/quotes-app-python" "${out}/bin/quotes-app-python-pure"
 """
 sandbox = "pure"
 runtime-packages = [

--- a/test.sh
+++ b/test.sh
@@ -16,7 +16,7 @@ ENVS=$(find ./* -type d -prune -print |xargs -0 | tr -d './')
 declare -a DEFAULT_BUILD_MODIFIERS
 DEFAULT_BUILD_MODIFIERS=("" "-pure")
 declare -a FIXME_BUILDS
-FIXME_BUILDS=("quotes-app-python-pure" "quotes-app-jvm-pure")
+FIXME_BUILDS=("quotes-app-jvm-pure")
 
 # Global test results
 declare -a TEST_RESULTS


### PR DESCRIPTION
This does a few things which were near impossible to split out to separate commits because none of the individual steps worked in isolation:

1. `poetry build && pip install` ensures that the source code for the project is copied into the virtualenv rather than leaving an editable reference to the original project path on the host machine.

2. `poetry install --no-root` creates a virtualenv and installs the dependencies to it, which we call separately for the pure build because it requires the network.

3. `unset VIRTUAL_ENV` ensures that the build still works when the Flox environment has been activated because the auto-setup hooks automatically create, activate, and install to the virtualenv which causes subsequent installs in impure builds to be a noop.

4. `cp ${venv_path}` replaces the symlink that we previously used because we don't currently wrap bin symlinks with the Flox wrapper and that means that they can't use any other packages from the build environment.

5. `mkdir $out` fixes this error which appears to only happen with `NIX_CONFIG="sandbox = true`:

    ```
    quotes-app-python-pure> 00:00:00.003686 + poetry install --no-root
    quotes-app-python-pure> 00:00:00.414093 Creating virtualenv quotes-app-python-1N0qLzbU-py3.12 in /nix/store/yfa0m3c22l6b2kb267zx8wf5vhdalmrx-quotes-app-python-pure-0.0.1
    quotes-app-python-pure> 00:00:00.440825 usage: virtualenv [--version] [--with-traceback] [-v | -q] [--read-only-app-data] [--app-data APP_DATA] [--reset-app-data] [--upgrade-embed-wheels] [--discovery {builtin}] [-p py] [--try-first-with py_exe]
    quotes-app-python-pure> 00:00:00.440825                   [--creator {builtin,cpython3-posix,venv}] [--seeder {app-data,pip}] [--no-seed] [--activators comma_sep_list] [--clear] [--no-vcs-ignore] [--system-site-packages] [--symlinks | --copies] [--no-download | --download]
    quotes-app-python-pure> 00:00:00.440825                   [--extra-search-dir d [d ...]] [--pip version] [--setuptools version] [--wheel version] [--no-pip] [--no-setuptools] [--no-wheel] [--no-periodic-update] [--symlink-app-data] [--prompt prompt] [-h]
    quotes-app-python-pure> 00:00:00.440825                   dest
    quotes-app-python-pure> 00:00:00.440845 virtualenv: error: argument dest: the destination . is not write-able at /nix/store
    ```