### PR TITLE
Add NEF build quotes-app-cpp-nix

### DIFF
--- a/quotes-app-cpp/.flox/env/manifest.lock
+++ b/quotes-app-cpp/.flox/env/manifest.lock
@@ -24,7 +24,7 @@
     },
     "build": {
       "quotes-app-cpp": {
-        "command": "  mkdir -p $out/{bin,lib,libexec}\n  make\n  cp -pr quotes.json $out/lib\n  cp -pr quotes-app-cpp $out/libexec\n  echo \"#!/usr/bin/env sh\" > $out/bin/quotes-app-cpp\n  echo \"export QUOTES_FILE=$out/lib/quotes.json\" >> $out/bin/quotes-app-cpp\n  echo \"exec $out/libexec/quotes-app-cpp\" >> $out/bin/quotes-app-cpp\n  chmod +x $out/bin/quotes-app-cpp\n",
+        "command": "  make\n  make install PREFIX=$out\n",
         "runtime-packages": [
           "boost"
         ],
@@ -32,7 +32,7 @@
         "description": "Quotes app written in C++"
       },
       "quotes-app-cpp-pure": {
-        "command": "  mkdir -p $out/{bin,lib,libexec}\n  make\n  cp -pr quotes.json $out/lib\n  cp -pr quotes-app-cpp $out/libexec\n  echo \"#!/usr/bin/env sh\" > $out/bin/quotes-app-cpp-pure\n  echo \"export QUOTES_FILE=$out/lib/quotes.json\" >> $out/bin/quotes-app-cpp-pure\n  echo \"exec $out/libexec/quotes-app-cpp\" >> $out/bin/quotes-app-cpp-pure\n  chmod +x $out/bin/quotes-app-cpp-pure\n",
+        "command": "  make\n  make install PREFIX=$out SUFFIX=\"-pure\"\n",
         "runtime-packages": [
           "boost"
         ],

--- a/quotes-app-cpp/.flox/env/manifest.toml
+++ b/quotes-app-cpp/.flox/env/manifest.toml
@@ -10,14 +10,8 @@ clang-tools.pkg-path = "clang-tools"
 version = "0.0.1"
 description = "Quotes app written in C++"
 command = """
-  mkdir -p $out/{bin,lib,libexec}
   make
-  cp -pr quotes.json $out/lib
-  cp -pr quotes-app-cpp $out/libexec
-  echo "#!/usr/bin/env sh" > $out/bin/quotes-app-cpp
-  echo "export QUOTES_FILE=$out/lib/quotes.json" >> $out/bin/quotes-app-cpp
-  echo "exec $out/libexec/quotes-app-cpp" >> $out/bin/quotes-app-cpp
-  chmod +x $out/bin/quotes-app-cpp
+  make install PREFIX=$out
 """
 # Need libboost.dylib at runtime.
 runtime-packages = [ "boost" ]
@@ -26,14 +20,8 @@ runtime-packages = [ "boost" ]
 version = "0.0.1"
 description = "Quotes app written in C++"
 command = """
-  mkdir -p $out/{bin,lib,libexec}
   make
-  cp -pr quotes.json $out/lib
-  cp -pr quotes-app-cpp $out/libexec
-  echo "#!/usr/bin/env sh" > $out/bin/quotes-app-cpp-pure
-  echo "export QUOTES_FILE=$out/lib/quotes.json" >> $out/bin/quotes-app-cpp-pure
-  echo "exec $out/libexec/quotes-app-cpp" >> $out/bin/quotes-app-cpp-pure
-  chmod +x $out/bin/quotes-app-cpp-pure
+  make install PREFIX=$out SUFFIX="-pure"
 """
 sandbox = "pure"
 # Need libboost.dylib at runtime.

--- a/quotes-app-cpp/.flox/pkgs/quotes-app-cpp-nix.nix
+++ b/quotes-app-cpp/.flox/pkgs/quotes-app-cpp-nix.nix
@@ -1,0 +1,16 @@
+{ stdenv, boost, lib }:
+
+stdenv.mkDerivation rec {
+  pname = "quotes-app-cpp";
+  version = "0.0.1";
+
+  src = ../../.;
+
+  buildInputs = [ boost ];
+
+  installFlags = [ "PREFIX=$(out)" "SUFFIX=-nix" ];
+
+  meta = with lib; {
+    description = "Quotes app written in C++";
+  };
+}

--- a/quotes-app-cpp/Makefile
+++ b/quotes-app-cpp/Makefile
@@ -14,6 +14,18 @@ endif
 all:
 	clang++ -O3 -std=c++17 quotes_server.cpp -o quotes-app-cpp -lboost_system -lboost_json -pthread
 
+install:
+ifndef PREFIX
+	$(error PREFIX is undefined)
+endif
+	mkdir -p $(PREFIX)/{bin,lib,libexec}
+	cp -pr quotes.json $(PREFIX)/lib
+	cp -pr quotes-app-cpp $(PREFIX)/libexec
+	echo "#!/usr/bin/env sh" > $(PREFIX)/bin/quotes-app-cpp$(SUFFIX)
+	echo "export QUOTES_FILE=$(PREFIX)/lib/quotes.json" >> $(PREFIX)/bin/quotes-app-cpp$(SUFFIX)
+	echo "exec $(PREFIX)/libexec/quotes-app-cpp" >> $(PREFIX)/bin/quotes-app-cpp$(SUFFIX)
+	chmod +x $(PREFIX)/bin/quotes-app-cpp$(SUFFIX)
+
 
 clean:
 	rm -f quotes-app-cpp

--- a/test.sh
+++ b/test.sh
@@ -18,7 +18,6 @@ DEFAULT_BUILD_MODIFIERS=("" "-pure" "-nix")
 declare -a FIXME_BUILDS
 FIXME_BUILDS=(
     "quotes-app-jvm-pure"
-    "quotes-app-cpp-nix"
     "quotes-app-go-nix"
     "quotes-app-jvm-nix"
     "quotes-app-nodejs-nix"


### PR DESCRIPTION
[Add make install target for cpp](https://github.com/flox/flox-manifest-build-examples/commit/f1f31edea7b44659a4d311074ec0de801040a655)

This factors out what is already duplicated between the sandbox off and
pure builds. And having an install target will be helpful for an NEF
build.

[Add NEF build quotes-app-cpp-nix](https://github.com/flox/flox-manifest-build-examples/commit/e4d610a6c42a2e42bc162fdda8964ee11e93de37)