### PR TITLE
feat: Nix build example for Go

### DIFF
--- a/quotes-app-go/.flox/pkgs/quotes-app-go-nix/default.nix
+++ b/quotes-app-go/.flox/pkgs/quotes-app-go-nix/default.nix
@@ -1,0 +1,17 @@
+{ buildGoModule }:
+
+let
+  src = ../../../.;
+in
+buildGoModule {
+  pname = "quotes-app-go-nix";
+  version = "0.1.0";
+
+  src = src;
+  # This must be updated when `go.mod` or `go.sum` are changed.
+  vendorHash = "sha256-8wYERVt3PIsKkarkwPu8Zy/Sdx43P6g2lz2xRfvTZ2E=";
+
+  postInstall = ''
+    mv $out/bin/quotes-app-go $out/bin/quotes-app-go-nix
+  '';
+}

--- a/test.sh
+++ b/test.sh
@@ -18,7 +18,6 @@ DEFAULT_BUILD_MODIFIERS=("" "-pure" "-nix")
 declare -a FIXME_BUILDS
 FIXME_BUILDS=(
     "quotes-app-jvm-pure"
-    "quotes-app-go-nix"
     "quotes-app-jvm-nix"
     "quotes-app-nodejs-nix"
     "quotes-app-php-nix"


### PR DESCRIPTION
References:

- https://nixos.org/manual/nixpkgs/stable/#sec-language-go
- https://flox.dev/docs/concepts/nix-expression-builds/#example-building-a-third-party-project

It can't generate a fixed output derivation with the correct hashes from `go.sum` alone so we have to provide a `vendorHash`. This seems fine while we only have a single dependency and CI will fail the build if incorrect.

An alternative would be to vendor the dependency, which I'm not super keen on because it's additional cruft in the repo and easy to get out-of-sync.