### PR TITLE
chore: pin GH actions to SHA

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -26,10 +26,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: "Install Nix"
-        uses: "cachix/install-nix-action@v31"
+        uses: cachix/install-nix-action@96951a368ba55167b55f1c916f7d416bac6505fe # v31
         with:
           # `accept-flake-config` is required for substitution despite of also
           # setting `substituters` and `trusted-public-keys` here.
@@ -65,7 +65,7 @@ jobs:
 
     steps:
       - name: "Slack Notification"
-        uses: "rtCamp/action-slack-notify@v2"
+        uses: rtCamp/action-slack-notify@e31e87e03dd19038e411e38ae27cbad084a90661 # v2
         env:
           SLACK_TITLE:      "Tests failed for manifest build examples"
           SLACK_FOOTER:     "Thank you for caring"


### PR DESCRIPTION
We now require this org wide.

Bump checkout to v6 while we're at it